### PR TITLE
Add pagination for house-estimate

### DIFF
--- a/src/house-estimate/dto/filter-house-estimate.dto.ts
+++ b/src/house-estimate/dto/filter-house-estimate.dto.ts
@@ -1,0 +1,14 @@
+// Dependencies
+import { ApiPropertyOptional, PartialType } from '@nestjs/swagger';
+
+// DTOs
+import { HouseEstimateDto } from './house-estimate.dto';
+
+export class FilterHouseEstimateDto extends PartialType(HouseEstimateDto) {
+  @ApiPropertyOptional()
+  page?: number;
+
+  @ApiPropertyOptional()
+  limit?: number;
+}
+

--- a/src/house-estimate/house-estimate.controller.ts
+++ b/src/house-estimate/house-estimate.controller.ts
@@ -1,5 +1,5 @@
 // Dependencies
-import { Controller, Get, Param, Patch, Body } from '@nestjs/common';
+import { Controller, Get, Param, Patch, Body, Query } from '@nestjs/common';
 import {
   ApiTags,
   ApiBearerAuth,
@@ -13,6 +13,7 @@ import { HouseEstimateService } from './house-estimate.service';
 // DTOs
 import { HouseEstimateDto } from './dto/house-estimate.dto';
 import { UpdateHouseEstimateDto } from './dto/update-house-estimate.dto';
+import { FilterHouseEstimateDto } from './dto/filter-house-estimate.dto';
 
 @ApiTags('House Estimate')
 @ApiBearerAuth()
@@ -21,11 +22,14 @@ export class HouseEstimateController {
   constructor(private readonly houseEstimateService: HouseEstimateService) {}
 
   @Get()
-  @ApiOperation({ summary: 'Lista house estimates' })
+  @ApiOperation({ summary: 'Lista house estimates com filtros e paginação' })
   @ApiOkResponse({ type: [HouseEstimateDto] })
-  async getAll(): Promise<HouseEstimateDto[]> {
-    const estimates = await this.houseEstimateService.getAll();
-    return estimates as unknown as HouseEstimateDto[];
+  async getAll(
+    @Query() filter: FilterHouseEstimateDto,
+  ): Promise<{ data: HouseEstimateDto[]; page: number; totalPages: number }> {
+    return (await this.houseEstimateService.getAll(
+      filter,
+    )) as unknown as { data: HouseEstimateDto[]; page: number; totalPages: number };
   }
 
   @Get(':id')

--- a/src/house-estimate/house-estimate.service.ts
+++ b/src/house-estimate/house-estimate.service.ts
@@ -7,6 +7,9 @@ import {
 } from '@nestjs/common';
 import { ObjectId, WithId, Document, Collection } from 'mongodb';
 
+// DTOs
+import { FilterHouseEstimateDto } from './dto/filter-house-estimate.dto';
+
 // Services
 import { MongoService } from '../mongo/mongo.service';
 
@@ -26,9 +29,27 @@ export class HouseEstimateService implements OnModuleInit {
     this.collection = this.mongoService.collection<HouseEstimate>('house_estimate');
   }
 
-  async getAll(): Promise<WithId<HouseEstimate>[]> {
+  async getAll(filter?: FilterHouseEstimateDto): Promise<{
+    data: WithId<HouseEstimate>[];
+    page: number;
+    totalPages: number;
+  }> {
     try {
-      return await this.collection.find().toArray();
+      const { page = 1, limit = 10, id, ...where } = filter ?? {};
+      if (id) {
+        Object.assign(where, { _id: new ObjectId(id) });
+      }
+      const skip = (page - 1) * limit;
+      const [data, total] = await Promise.all([
+        this.collection
+          .find(where)
+          .skip(skip)
+          .limit(Number(limit))
+          .toArray(),
+        this.collection.countDocuments(where),
+      ]);
+      const totalPages = Math.ceil(total / Number(limit));
+      return { data, page, totalPages };
     } catch (error) {
       this.logger.error('Failed to fetch house estimates', error);
       throw new InternalServerErrorException('Failed to fetch house estimates');


### PR DESCRIPTION
## Summary
- add `FilterHouseEstimateDto` with page and limit
- update house estimate controller to support pagination
- paginate results in house estimate service

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6888240d0c4c8325a10237d2d66d0d8d