### PR TITLE
chore: configure heroku deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+release: npm run db:migrate
+web: npm run start:prod

--- a/README.md
+++ b/README.md
@@ -108,6 +108,21 @@ $ mau deploy
 
 With Mau, you can deploy your application in just a few clicks, allowing you to focus on building features rather than managing infrastructure.
 
+## Deploy to Heroku
+
+Heroku builds the project with the included `Procfile` and runs database migrations automatically. Basic deployment flow:
+
+```bash
+# login and create app
+heroku login
+heroku create your-app-name
+
+# push code
+git push heroku main
+```
+
+Set the required environment variables in Heroku, including the `DATABASE_URL` and any values from `.env.example`.
+
 ## Resources
 
 Check out a few resources that may come in handy when working with NestJS:

--- a/package.json
+++ b/package.json
@@ -5,19 +5,25 @@
   "author": "",
   "private": true,
   "license": "UNLICENSED",
+  "engines": {
+    "node": "20.x"
+  },
   "scripts": {
     "build": "nest build",
+    "db:migrate": "prisma migrate deploy",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
-    "start": "nest start",
-    "start:dev": "nest start --watch",
-    "start:debug": "nest start --debug --watch",
-    "start:prod": "node dist/main",
+    "heroku-postbuild": "npm run build",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "postinstall": "prisma generate",
+    "start": "nest start",
+    "start:debug": "nest start --debug --watch",
+    "start:dev": "nest start --watch",
+    "start:prod": "node dist/main",
     "test": "jest",
-    "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.850.0",


### PR DESCRIPTION
## Summary
- add Procfile for Heroku release and web processes
- script heroku build, Prisma client generation, and migrations
- document Heroku deployment steps

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9474a99c8325814877eb7a4075c2