### PR TITLE
fix: import Prisma module for waiting list

### DIFF
--- a/src/waiting-list/waiting-list.module.ts
+++ b/src/waiting-list/waiting-list.module.ts
@@ -4,10 +4,14 @@ import { Module } from '@nestjs/common';
 // Services
 import { WaitingListService } from './waiting-list.service';
 
+// Modules
+import { PrismaModule } from '../prisma/prisma.module';
+
 // Controllers
 import { WaitingListController } from './waiting-list.controller';
 
 @Module({
+  imports: [PrismaModule],
   controllers: [WaitingListController],
   providers: [WaitingListService],
 })


### PR DESCRIPTION
## Summary
- fix dependency injection in WaitingListModule by importing PrismaModule

## Testing
- `npm test` *(fails: Nest can't resolve dependencies of UserService in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68acaa1417f48325850bad7810b67781