### PR TITLE
fix: remove duplicate prisma module import

### DIFF
--- a/src/waiting-list/waiting-list.module.ts
+++ b/src/waiting-list/waiting-list.module.ts
@@ -1,14 +1,11 @@
 // Dependencies
 import { Module } from '@nestjs/common';
-import { PrismaModule } from '../prisma/prisma.module';
 
 // Services
-import { WaitingListService } from './waiting-list.service';
-
-// Modules
 import { PrismaModule } from '../prisma/prisma.module';
 
-// Controllers
+// Local
+import { WaitingListService } from './waiting-list.service';
 import { WaitingListController } from './waiting-list.controller';
 
 @Module({


### PR DESCRIPTION
### **User description**
## Summary
- remove duplicate `PrismaModule` import and organize imports in waiting list module

## Testing
- `npm test` *(fails: Nest can't resolve dependencies of the UserService)*

------
https://chatgpt.com/codex/tasks/task_e_68b6186115c88325b16389ce1126162c


___

### **PR Type**
Bug fix


___

### **Description**
- Remove duplicate `PrismaModule` import

- Reorganize imports by category


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Duplicate PrismaModule imports"] --> B["Single PrismaModule import"]
  C["Scattered imports"] --> D["Organized imports by category"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>waiting-list.module.ts</strong><dd><code>Remove duplicate import and organize structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/waiting-list/waiting-list.module.ts

<ul><li>Remove duplicate <code>PrismaModule</code> import declaration<br> <li> Reorganize imports into logical sections (Dependencies, Local)<br> <li> Clean up import structure and spacing</ul>


</details>


  </td>
  <td><a href="https://github.com/edwinreuleneto/houser-api-core/pull/11/files#diff-6540e4a3e13915903add788f0538e8996d9b4eabf0d2c7887e131880cd7f9d6e">+2/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

